### PR TITLE
fix: mark api-key and deployment-api-key as isSecret in config_schema

### DIFF
--- a/cmd/baton-elastic/config.go
+++ b/cmd/baton-elastic/config.go
@@ -8,6 +8,7 @@ var (
 	APIKeyField = field.StringField(
 		"api-key",
 		field.WithDescription("Elastic Cloud API key used to communicate with Elastic Cloud API. Can be set via $BATON_API_KEY."),
+		field.WithIsSecret(true),
 	)
 
 	OrganizationIDField = field.StringField(
@@ -18,6 +19,7 @@ var (
 	DeploymentAPIKeyField = field.StringField(
 		"deployment-api-key",
 		field.WithDescription("API key of your Elasticsearch deployment."),
+		field.WithIsSecret(true),
 	)
 
 	DeploymentEndpointField = field.StringField(


### PR DESCRIPTION
The `api-key` (Elastic Cloud API key) and `deployment-api-key` (Elasticsearch deployment API key) fields are credentials but were plain `field.StringField` with no `field.WithIsSecret(true)`, so neither was marked secret. This adds `WithIsSecret(true)` to both. `organization-id` and `deployment-endpoint` are not credentials and are correctly left unmarked.

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

_Built with stargate._
